### PR TITLE
Make dictionary selectable from TitlePage for quicker switching.

### DIFF
--- a/qml/pages/TitlePage.qml
+++ b/qml/pages/TitlePage.qml
@@ -225,15 +225,16 @@ Page {
 
                             width: parent.width
 
-                            // Simple, invisible spacer from the top
-                            Rectangle {
-                                width: Theme.paddingLarge
-                                height: Theme.paddingLarge
-                                opacity: 0.0
-                            }
-
                             PageHeader {
                                 id: header
+
+                                // Simple, invisible spacer from the top
+                                Rectangle {
+                                    width: Theme.paddingLarge
+                                    height: Theme.paddingLarge
+                                    opacity: 0.0
+                                }
+
                                 ComboBox {
                                     id: headerDictionaryBox
                                     label: qsTranslate("DictionariesPage", "Dictionary")

--- a/qml/pages/TitlePage.qml
+++ b/qml/pages/TitlePage.qml
@@ -225,14 +225,39 @@ Page {
 
                             width: parent.width
 
+                            // Simple, invisible spacer from the top
+                            Rectangle {
+                                width: Theme.paddingLarge
+                                height: Theme.paddingLarge
+                                opacity: 0.0
+                            }
+
                             PageHeader {
                                 id: header
-                                title: dictionaryModel.getSelectedDictionaryName()
-                                Connections {
-                                    target: dictionaryModel
-                                    onDictionaryChanged: {
-                                        header.title = dictionaryModel.getSelectedDictionaryName()
-                                        heinzelnisseModel.search(searchField.text)
+                                ComboBox {
+                                    id: headerDictionaryBox
+                                    label: qsTranslate("DictionariesPage", "Dictionary")
+                                    currentIndex: dictionaryModel.getSelectedDictionaryIndex()
+                                    description: qsTranslate("DictionariesPage", "Choose the active dictionary here")
+                                    menu: ContextMenu {
+                                        Repeater {
+                                            model: dictionaryModel
+                                            delegate: MenuItem {
+                                                text: display.languages
+                                            }
+                                        }
+                                        onActivated: {
+                                            dictionaryModel.selectDictionary(index);
+                                        }
+                                    }
+
+                                    Connections {
+                                        // If dictionary is changed from DictionariesPage, we have to update index and search.
+                                        target: dictionaryModel
+                                        onDictionaryChanged: {
+                                            headerDictionaryBox.currentIndex = dictionaryModel.getSelectedDictionaryIndex()
+                                            heinzelnisseModel.search(searchField.text)
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
It always bugged me to "click" 4 times in order to switch languages.
So I replaced the header from TitlePage with the ComboBox from DictionariesPage, added some Connections and a spacer from the top for consistent usage.
Also reused translations from DictionariesPage, so no need to duplicate those.