### PR TITLE
Updated Azure API endpoints

### DIFF
--- a/src/cloudapi.cpp
+++ b/src/cloudapi.cpp
@@ -64,6 +64,7 @@ void CloudApi::translate(const QString &text, const QString &targetLanguage)
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     request.setRawHeader(QByteArray("Ocp-Apim-Subscription-Key"), settings.value(SETTINGS_TRANSLATOR_TEXT_KEY).toByteArray());
+    request.setRawHeader(QByteArray("Ocp-Apim-Subscription-Region"), "northeurope");
 
     QJsonObject jsonText;
     jsonText.insert("Text", text);

--- a/src/cloudapi.h
+++ b/src/cloudapi.h
@@ -34,7 +34,7 @@
 #include <QFile>
 #include <QSettings>
 
-const char API_OCR[] = "https://westeurope.api.cognitive.microsoft.com/vision/v1.0/ocr";
+const char API_OCR[] = "https://wunderfitz.cognitiveservices.azure.com/vision/v1.0/ocr";
 const char API_TRANSLATE[] = "https://api.cognitive.microsofttranslator.com/translate";
 
 class CloudApi : public QObject


### PR DESCRIPTION
Two changes:

1. Updates the OCR endpoint URL.
2. Adds region authentication header for Text Translator call.

This is just a demonstration PR to highlight the problem (hence set as draft). I expect additional changes are really needed to make these values configuration through the API.

If I get the chance I'll try to update the UI with the necessary fields to allow this to be properly configured:
1. `wunderfitz` should be replaced by the Azure resource name chosen by the user.
2. `northeurope` should be optional and configurable in case Azure has been configured as a [regional resource](https://docs.microsoft.com/en-gb/azure/cognitive-services/translator/reference/v3-0-reference#authenticating-with-a-regional-resource).