### PR TITLE
Update Azure Vision API to v4.0, improve Result tab UI, and update translations

### DIFF
--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -53,7 +53,7 @@ Page {
             TextField {
                 id: computerVisionKeyField
                 width: parent.width
-                placeholderText: qsTr("Azure Computer Vision API Key")
+                placeholderText: qsTr("Azure AI Vision API Key")
                 label: placeholderText
                 onTextChanged: curiosity.setComputerVisionKey(text)
             }
@@ -61,7 +61,7 @@ Page {
             TextField {
                 id: computerVisionEndpointField
                 width: parent.width
-                placeholderText: qsTr("Azure Computer Vision Endpoint")
+                placeholderText: qsTr("Azure AI Vision Endpoint")
                 label: placeholderText
                 onTextChanged: curiosity.setComputerVisionEndpoint(text)
             }

--- a/qml/pages/TextPage.qml
+++ b/qml/pages/TextPage.qml
@@ -37,13 +37,13 @@ Page {
             MenuItem {
                 text: qsTr("Copy translation to clipboard")
                 onClicked: {
-                    Clipboard.text = translationContent.text
+                    Clipboard.text = textPage.translation
                 }
             }
             MenuItem {
                 text: qsTr("Copy original to clipboard")
                 onClicked: {
-                    Clipboard.text = originalContent.text
+                    Clipboard.text = textPage.original
                 }
             }
         }
@@ -51,49 +51,36 @@ Page {
         Column {
             id: column
             width: textPage.width
-            spacing: Theme.paddingLarge
 
             PageHeader {
-                id: textHeader
                 title: qsTr("Result")
             }
 
             SectionHeader {
-                id: originalHeader
                 text: qsTr("Original")
             }
 
-            Text {
-                id: originalContent
-                width: parent.width - 2 * Theme.horizontalPageMargin
-                anchors.horizontalCenter: parent.horizontalCenter
+            TextArea {
+                width: parent.width
+                wrapMode: TextEdit.Wrap
                 font.pixelSize: Theme.fontSizeMedium
-                color: Theme.primaryColor
-                linkColor: Theme.highlightColor
-                wrapMode: Text.Wrap
-                textFormat: Text.PlainText
                 text: textPage.original
             }
 
             SectionHeader {
-                id: translationHeader
                 text: qsTr("Translation")
             }
 
-            Text {
-                id: translationContent
-                width: parent.width - 2 * Theme.horizontalPageMargin
-                anchors.horizontalCenter: parent.horizontalCenter
+            TextArea {
+                width: parent.width
+                wrapMode: TextEdit.Wrap
                 font.pixelSize: Theme.fontSizeMedium
-                color: Theme.primaryColor
-                linkColor: Theme.highlightColor
-                wrapMode: Text.Wrap
-                textFormat: Text.PlainText
                 text: textPage.translation
             }
 
-            VerticalScrollDecorator {}
+            Item { width: parent.width; height: Theme.paddingLarge }
         }
 
+        VerticalScrollDecorator {}
     }
 }

--- a/qml/pages/TitlePage.qml
+++ b/qml/pages/TitlePage.qml
@@ -30,6 +30,7 @@ Page {
     property bool interactionHintDisplayed : dictionaryModel.isInteractionHintDisplayed()
     property string lastOriginal: ""
     property string lastTranslation: ""
+    property bool hasResult: lastOriginal !== "" || lastTranslation !== ""
 
     function toggleBusyIndicator() {
         busyIndicator.running = heinzelnisseModel.isSearchInProgress()
@@ -1179,23 +1180,18 @@ Page {
                                 id: resultColumn
                                 width: parent.width
 
-                                PageHeader {
-                                    title: qsTr("Result")
-                                }
-
                                 SectionHeader {
                                     text: qsTr("Original")
                                 }
 
                                 TextArea {
-                                    id: resultOriginalText
+                                    id: originalTextArea
                                     width: parent.width
                                     wrapMode: TextEdit.Wrap
-                                    font.pixelSize: Theme.fontSizeMedium
                                     text: titlePage.lastOriginal
                                     Connections {
                                         target: titlePage
-                                        onLastOriginalChanged: resultOriginalText.text = titlePage.lastOriginal
+                                        onLastOriginalChanged: originalTextArea.text = titlePage.lastOriginal
                                     }
                                 }
 
@@ -1204,18 +1200,15 @@ Page {
                                 }
 
                                 TextArea {
-                                    id: resultTranslationText
+                                    id: translationTextArea
                                     width: parent.width
                                     wrapMode: TextEdit.Wrap
-                                    font.pixelSize: Theme.fontSizeMedium
                                     text: titlePage.lastTranslation
                                     Connections {
                                         target: titlePage
-                                        onLastTranslationChanged: resultTranslationText.text = titlePage.lastTranslation
+                                        onLastTranslationChanged: translationTextArea.text = titlePage.lastTranslation
                                     }
                                 }
-
-                                Item { width: parent.width; height: Theme.paddingLarge }
                             }
 
                             VerticalScrollDecorator {}
@@ -1246,7 +1239,12 @@ Page {
                     clip: true
                     model: viewsModel
                     onCurrentIndexChanged: {
-                        openTab(currentIndex);
+                        if (currentIndex === 2 && !titlePage.hasResult) {
+                            slideshowVisibleTimer.goToTab(1);
+                            openTab(1);
+                        } else {
+                            openTab(currentIndex);
+                        }
                     }
                     Behavior on opacity { NumberAnimation {} }
                     onOpacityChanged: {
@@ -1308,6 +1306,7 @@ Page {
                             id: resultButtonColumnLandscape
                             height: parent.height / 3
                             width: parent.width - Theme.paddingMedium
+                            visible: titlePage.hasResult
                             Column {
                                 id: resultButtonLandscape
                                 property bool isActive: false
@@ -1385,6 +1384,7 @@ Page {
                         id: resultButtonColumn
                         width: parent.width / 3
                         height: parent.height - navigationRowSeparator.height
+                        visible: titlePage.hasResult
                         Column {
                             id: resultButtonPortrait
                             property bool isActive: false

--- a/qml/pages/TitlePage.qml
+++ b/qml/pages/TitlePage.qml
@@ -1085,7 +1085,7 @@ Page {
                                     linkColor: Theme.highlightColor
                                     wrapMode: Text.Wrap
                                     textFormat: Text.StyledText
-                                    text: qsTr("The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the <a href=\"https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/\">Computer Vision</a> and the <a href=\"https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/\">Translator Text</a> API, enter them on the settings page and have fun!")
+                                    text: qsTr("The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for <a href=\"https://azure.microsoft.com/en-us/products/ai-services/ai-vision\">Azure AI Vision</a> and the <a href=\"https://azure.microsoft.com/en-us/products/ai-services/ai-translator\">Azure AI Translator</a> API, enter them on the settings page and have fun!")
 
                                     onLinkActivated: Qt.openUrlExternally(link);
                                 }

--- a/qml/pages/TitlePage.qml
+++ b/qml/pages/TitlePage.qml
@@ -28,6 +28,8 @@ Page {
 
     property int activeTabId: 0;
     property bool interactionHintDisplayed : dictionaryModel.isInteractionHintDisplayed()
+    property string lastOriginal: ""
+    property string lastTranslation: ""
 
     function toggleBusyIndicator() {
         busyIndicator.running = heinzelnisseModel.isSearchInProgress()
@@ -50,12 +52,24 @@ Page {
             dictionariesButtonLandscape.isActive = true;
             wunderfitzButtonPortrait.isActive = false;
             wunderfitzButtonLandscape.isActive = false;
+            resultButtonPortrait.isActive = false;
+            resultButtonLandscape.isActive = false;
             break;
         case 1:
             dictionariesButtonPortrait.isActive = false;
             dictionariesButtonLandscape.isActive = false;
             wunderfitzButtonPortrait.isActive = true;
             wunderfitzButtonLandscape.isActive = true;
+            resultButtonPortrait.isActive = false;
+            resultButtonLandscape.isActive = false;
+            break;
+        case 2:
+            dictionariesButtonPortrait.isActive = false;
+            dictionariesButtonLandscape.isActive = false;
+            wunderfitzButtonPortrait.isActive = false;
+            wunderfitzButtonLandscape.isActive = false;
+            resultButtonPortrait.isActive = true;
+            resultButtonLandscape.isActive = true;
             break;
         default:
             console.log("Some strange navigation happened!")
@@ -79,6 +93,16 @@ Page {
             viewsSlideshow.opacity = 0;
             slideshowVisibleTimer.goToTab(1);
             openTab(1);
+        }
+    }
+
+    function handleResultClicked() {
+        if (titlePage.activeTabId === 2) {
+            resultFlickable.scrollToTop();
+        } else {
+            viewsSlideshow.opacity = 0;
+            slideshowVisibleTimer.goToTab(2);
+            openTab(2);
         }
     }
 
@@ -123,6 +147,16 @@ Page {
                 visible: titlePage.activeTabId === 0
                 text: qsTr("Dictionaries")
                 onClicked: pageStack.push(dictionariesPage)
+            }
+            MenuItem {
+                visible: titlePage.activeTabId === 2
+                text: qsTr("Copy translation to clipboard")
+                onClicked: Clipboard.text = titlePage.lastTranslation
+            }
+            MenuItem {
+                visible: titlePage.activeTabId === 2
+                text: qsTr("Copy original to clipboard")
+                onClicked: Clipboard.text = titlePage.lastOriginal
             }
         }
 
@@ -416,7 +450,11 @@ Page {
                                     onTranslationSuccessful: {
                                         wunderfitzView.isProcessing = false;
                                         previewImage.visible = false;
-                                        pageStack.push(Qt.resolvedUrl("../pages/TextPage.qml"), {"original": curiosity.getTranslatedText(), "translation": text});
+                                        titlePage.lastOriginal = curiosity.getTranslatedText();
+                                        titlePage.lastTranslation = text;
+                                        viewsSlideshow.opacity = 0;
+                                        slideshowVisibleTimer.goToTab(2);
+                                        openTab(2);
                                     }
                                     onTranslationError: {
                                         wunderfitzView.isProcessing = false;
@@ -1126,6 +1164,63 @@ Page {
                         }
 
                     }
+
+                    Item {
+                        id: resultView
+                        width: viewsSlideshow.width
+                        height: viewsSlideshow.height
+
+                        SilicaFlickable {
+                            id: resultFlickable
+                            contentHeight: resultColumn.height
+                            anchors.fill: parent
+
+                            Column {
+                                id: resultColumn
+                                width: parent.width
+
+                                PageHeader {
+                                    title: qsTr("Result")
+                                }
+
+                                SectionHeader {
+                                    text: qsTr("Original")
+                                }
+
+                                TextArea {
+                                    id: resultOriginalText
+                                    width: parent.width
+                                    wrapMode: TextEdit.Wrap
+                                    font.pixelSize: Theme.fontSizeMedium
+                                    text: titlePage.lastOriginal
+                                    Connections {
+                                        target: titlePage
+                                        onLastOriginalChanged: resultOriginalText.text = titlePage.lastOriginal
+                                    }
+                                }
+
+                                SectionHeader {
+                                    text: qsTr("Translation")
+                                }
+
+                                TextArea {
+                                    id: resultTranslationText
+                                    width: parent.width
+                                    wrapMode: TextEdit.Wrap
+                                    font.pixelSize: Theme.fontSizeMedium
+                                    text: titlePage.lastTranslation
+                                    Connections {
+                                        target: titlePage
+                                        onLastTranslationChanged: resultTranslationText.text = titlePage.lastTranslation
+                                    }
+                                }
+
+                                Item { width: parent.width; height: Theme.paddingLarge }
+                            }
+
+                            VerticalScrollDecorator {}
+                        }
+                    }
                 }
 
                 Timer {
@@ -1189,7 +1284,7 @@ Page {
 
                         Item {
                             id: dictionariesButtonColumnLandscape
-                            height: parent.height / 2
+                            height: parent.height / 3
                             width: parent.width - Theme.paddingMedium
                             DictionaryButton {
                                 id: dictionariesButtonLandscape
@@ -1200,12 +1295,43 @@ Page {
 
                         Item {
                             id: wunderfitzButtonColumnLandscape
-                            height: parent.height / 2
+                            height: parent.height / 3
                             width: parent.width - Theme.paddingMedium
                             WunderfitzButton {
                                 id: wunderfitzButtonLandscape
                                 visible: (isActive || !navigationColumn.squeezed)
                                 anchors.verticalCenter: parent.verticalCenter
+                            }
+                        }
+
+                        Item {
+                            id: resultButtonColumnLandscape
+                            height: parent.height / 3
+                            width: parent.width - Theme.paddingMedium
+                            Column {
+                                id: resultButtonLandscape
+                                property bool isActive: false
+                                width: parent.width
+                                anchors.verticalCenter: parent.verticalCenter
+                                visible: (isActive || !navigationColumn.squeezed)
+                                IconButton {
+                                    icon.source: resultButtonLandscape.isActive ? "image://theme/icon-m-note?" + Theme.highlightColor : "image://theme/icon-m-note?" + Theme.primaryColor
+                                    height: Theme.iconSizeMedium
+                                    width: Theme.iconSizeMedium
+                                    anchors.horizontalCenter: parent.horizontalCenter
+                                    onClicked: handleResultClicked()
+                                }
+                                Label {
+                                    text: qsTr("Result")
+                                    font.pixelSize: Theme.fontSizeTiny
+                                    color: resultButtonLandscape.isActive ? Theme.highlightColor : Theme.primaryColor
+                                    truncationMode: TruncationMode.Fade
+                                    anchors.horizontalCenter: parent.horizontalCenter
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        onClicked: handleResultClicked()
+                                    }
+                                }
                             }
                         }
 
@@ -1237,7 +1363,7 @@ Page {
                     width: parent.width
                     Item {
                         id: dictionariesButtonColumn
-                        width: parent.width / 2
+                        width: parent.width / 3
                         height: parent.height - Theme.paddingMedium
                         DictionaryButton {
                             id: dictionariesButtonPortrait
@@ -1247,11 +1373,41 @@ Page {
 
                     Item {
                         id: notificationsButtonColumn
-                        width: parent.width / 2
+                        width: parent.width / 3
                         height: parent.height - navigationRowSeparator.height
                         WunderfitzButton {
                             id: wunderfitzButtonPortrait
                             anchors.top: parent.top
+                        }
+                    }
+
+                    Item {
+                        id: resultButtonColumn
+                        width: parent.width / 3
+                        height: parent.height - navigationRowSeparator.height
+                        Column {
+                            id: resultButtonPortrait
+                            property bool isActive: false
+                            width: parent.width
+                            anchors.top: parent.top
+                            IconButton {
+                                icon.source: resultButtonPortrait.isActive ? "image://theme/icon-m-note?" + Theme.highlightColor : "image://theme/icon-m-note?" + Theme.primaryColor
+                                height: Theme.iconSizeMedium
+                                width: Theme.iconSizeMedium
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                onClicked: handleResultClicked()
+                            }
+                            Label {
+                                text: qsTr("Result")
+                                font.pixelSize: Theme.fontSizeTiny
+                                color: resultButtonPortrait.isActive ? Theme.highlightColor : Theme.primaryColor
+                                truncationMode: TruncationMode.Fade
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                MouseArea {
+                                    anchors.fill: parent
+                                    onClicked: handleResultClicked()
+                                }
+                            }
                         }
                     }
                 }

--- a/quazip/quazip/wunderfitz-quazip.pro
+++ b/quazip/quazip/wunderfitz-quazip.pro
@@ -1,7 +1,7 @@
 TEMPLATE = lib
 CONFIG += qt warn_on
 QT -= gui
-!win32:VERSION = 1.0.0
+CONFIG += unversioned_libname unversioned_soname
 TARGET = quazip
 
 DEFINES += QUAZIP_BUILD

--- a/rpm/harbour-wunderfitz.spec
+++ b/rpm/harbour-wunderfitz.spec
@@ -6,8 +6,6 @@
 Name:       harbour-wunderfitz
 
 # >> macros
-%define __provides_exclude_from ^%{_datadir}/.*$
-%define __requires_exclude ^libquazip.*$
 # << macros
 
 %{!?qtc_qmake:%define qtc_qmake %qmake}
@@ -28,6 +26,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(zlib)
+BuildRequires:  pkgconfig(sailfishsecrets)
 BuildRequires:  desktop-file-utils
 
 %description

--- a/rpm/harbour-wunderfitz.yaml
+++ b/rpm/harbour-wunderfitz.yaml
@@ -26,6 +26,7 @@ PkgConfigBR:
   - Qt5Qml
   - Qt5Quick
   - zlib
+  - sailfishsecrets
 
 # Build dependencies without a pkgconfig setup can be listed here
 # PkgBR:

--- a/src/cloudapi.cpp
+++ b/src/cloudapi.cpp
@@ -33,13 +33,16 @@ void CloudApi::opticalCharacterRecognition(const QString &imagePath, const QStri
 
     QUrl url = QUrl(curiosity->getComputerVisionEndpoint());
     url.setPath(url.path() + API_COMPUTER_VISION_ENDPOINT_PATH);
+    QUrlQuery urlQuery = QUrlQuery();
+    urlQuery.addQueryItem("api-version", "2024-02-01");
+    urlQuery.addQueryItem("features", "read");
+    if (sourceLanguage != "unk") {
+        urlQuery.addQueryItem("language", sourceLanguage);
+    }
+    url.setQuery(urlQuery);
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/octet-stream");
     request.setRawHeader(QByteArray("Ocp-Apim-Subscription-Key"), curiosity->getComputerVisionKey().toLocal8Bit());
-    QUrlQuery urlQuery = QUrlQuery();
-    urlQuery.addQueryItem("language", sourceLanguage);
-    urlQuery.addQueryItem("detectOrientation", "true");
-    url.setQuery(urlQuery);
 
     QFile *file = new QFile(imagePath);
     file->open(QIODevice::ReadOnly);
@@ -96,8 +99,17 @@ void CloudApi::handleOcrUploadError(QNetworkReply::NetworkError error)
 {
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
     reply->deleteLater();
-    qWarning() << "CloudApi::handleOcrUploadError:" << (int)error << reply->errorString() << reply->readAll();
-    emit ocrUploadError(reply->objectName(), reply->errorString());
+    QString responseBody = QString::fromUtf8(reply->readAll());
+    qWarning() << "CloudApi::handleOcrUploadError:" << (int)error << reply->errorString() << responseBody;
+    QJsonDocument errorDoc = QJsonDocument::fromJson(responseBody.toUtf8());
+    QString errorMessage = reply->errorString();
+    if (errorDoc.isObject()) {
+        QJsonObject errorObj = errorDoc.object().value("error").toObject();
+        if (!errorObj.isEmpty()) {
+            errorMessage = errorObj.value("message").toString();
+        }
+    }
+    emit ocrUploadError(reply->objectName(), errorMessage);
 }
 
 void CloudApi::handleOcrUploadFinished()
@@ -121,8 +133,17 @@ void CloudApi::handleTranslateError(QNetworkReply::NetworkError error)
 {
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
     reply->deleteLater();
-    qWarning() << "CloudApi::handleTranslateError:" << (int)error << reply->errorString() << reply->readAll();
-    emit translateError(reply->errorString());
+    QString responseBody = QString::fromUtf8(reply->readAll());
+    qWarning() << "CloudApi::handleTranslateError:" << (int)error << reply->errorString() << responseBody;
+    QString errorMessage = reply->errorString();
+    QJsonDocument errorDoc = QJsonDocument::fromJson(responseBody.toUtf8());
+    if (errorDoc.isObject()) {
+        QJsonObject errorObj = errorDoc.object().value("error").toObject();
+        if (!errorObj.isEmpty()) {
+            errorMessage = errorObj.value("message").toString();
+        }
+    }
+    emit translateError(errorMessage);
 }
 
 void CloudApi::handleTranslateFinished()

--- a/src/cloudapi.h
+++ b/src/cloudapi.h
@@ -34,7 +34,7 @@
 #include <QFile>
 #include <QSettings>
 
-const char API_COMPUTER_VISION_ENDPOINT_PATH[] = "/vision/v1.0/ocr";
+const char API_COMPUTER_VISION_ENDPOINT_PATH[] = "/computervision/imageanalysis:analyze";
 const char API_TRANSLATOR_TEXT_ENDPOINT_PATH[] = "/translate";
 
 class Curiosity;

--- a/src/curiosity.cpp
+++ b/src/curiosity.cpp
@@ -189,18 +189,16 @@ CloudApi *Curiosity::getCloudApi()
 void Curiosity::handleOcrProcessingSuccessful(const QString &fileName, const QJsonObject &result)
 {
     qDebug() << "[Curiosity] Processing OCR result..." << fileName;
-    QJsonArray regionArray = result.value("regions").toArray();
+    QJsonObject readResult = result.value("readResult").toObject();
+    QJsonArray blockArray = readResult.value("blocks").toArray();
     QString completeText;
-    foreach (const QJsonValue &region, regionArray) {
-        QJsonArray lineArray = region.toObject().value("lines").toArray();
+    foreach (const QJsonValue &block, blockArray) {
+        QJsonArray lineArray = block.toObject().value("lines").toArray();
         foreach (const QJsonValue &line, lineArray) {
-            QJsonArray wordArray = line.toObject().value("words").toArray();
-            foreach (const QJsonValue &word, wordArray) {
-                if (!completeText.isEmpty()) {
-                    completeText.append(" ");
-                }
-                completeText.append(word.toObject().value("text").toString());
+            if (!completeText.isEmpty()) {
+                completeText.append(" ");
             }
+            completeText.append(line.toObject().value("text").toString());
         }
     }
     qDebug() << completeText;

--- a/src/curiosity.cpp
+++ b/src/curiosity.cpp
@@ -29,6 +29,9 @@
 #include <QMatrix>
 #include <QRect>
 #include <QJsonObject>
+#include <Secrets/createcollectionrequest.h>
+#include <Secrets/storesecretrequest.h>
+#include <Secrets/storedsecretrequest.h>
 
 #include "cloudapi.h"
 
@@ -128,13 +131,27 @@ QString Curiosity::getTranslatedText()
 
 void Curiosity::setComputerVisionKey(const QString &computerVisionKey)
 {
-    qDebug() << "[Curiosity] Set computer vision key" << computerVisionKey;
-    settings.setValue(SETTINGS_COMPUTER_VISION_KEY, computerVisionKey);
+    qDebug() << "[Curiosity] Set computer vision key";
+    secretsWriteKey(QLatin1String(SECRETS_SECRET_CV_KEY), computerVisionKey);
 }
 
 QString Curiosity::getComputerVisionKey()
 {
-    return settings.value(SETTINGS_COMPUTER_VISION_KEY, "").toString();
+    if (settings.contains(SETTINGS_COMPUTER_VISION_KEY)) {
+        QString legacyValue = settings.value(SETTINGS_COMPUTER_VISION_KEY).toString();
+        if (!legacyValue.isEmpty()) {
+            if (secretsWriteKey(QLatin1String(SECRETS_SECRET_CV_KEY), legacyValue)) {
+                settings.remove(SETTINGS_COMPUTER_VISION_KEY);
+                qDebug() << "[Curiosity] Migrated computer vision key to Secrets";
+            } else {
+                qWarning() << "[Curiosity] Migration of computer vision key failed; retaining QSettings value";
+                return legacyValue;
+            }
+        } else {
+            settings.remove(SETTINGS_COMPUTER_VISION_KEY);
+        }
+    }
+    return secretsReadKey(QLatin1String(SECRETS_SECRET_CV_KEY));
 }
 
 void Curiosity::setComputerVisionEndpoint(const QString &computerVisionEndpoint)
@@ -150,13 +167,27 @@ QString Curiosity::getComputerVisionEndpoint()
 
 void Curiosity::setTranslatorTextKey(const QString &translatorTextKey)
 {
-    qDebug() << "[Curiosity] Set translator text key" << translatorTextKey;
-    settings.setValue(SETTINGS_TRANSLATOR_TEXT_KEY, translatorTextKey);
+    qDebug() << "[Curiosity] Set translator text key";
+    secretsWriteKey(QLatin1String(SECRETS_SECRET_TR_KEY), translatorTextKey);
 }
 
 QString Curiosity::getTranslatorTextKey()
 {
-    return settings.value(SETTINGS_TRANSLATOR_TEXT_KEY, "").toString();
+    if (settings.contains(SETTINGS_TRANSLATOR_TEXT_KEY)) {
+        QString legacyValue = settings.value(SETTINGS_TRANSLATOR_TEXT_KEY).toString();
+        if (!legacyValue.isEmpty()) {
+            if (secretsWriteKey(QLatin1String(SECRETS_SECRET_TR_KEY), legacyValue)) {
+                settings.remove(SETTINGS_TRANSLATOR_TEXT_KEY);
+                qDebug() << "[Curiosity] Migrated translator text key to Secrets";
+            } else {
+                qWarning() << "[Curiosity] Migration of translator text key failed; retaining QSettings value";
+                return legacyValue;
+            }
+        } else {
+            settings.remove(SETTINGS_TRANSLATOR_TEXT_KEY);
+        }
+    }
+    return secretsReadKey(QLatin1String(SECRETS_SECRET_TR_KEY));
 }
 
 void Curiosity::setTranslatorTextEndpoint(const QString &translatorTextEndpoint)
@@ -179,6 +210,67 @@ void Curiosity::setTranslatorTextRegion(const QString &translatorTextRegion)
 QString Curiosity::getTranslatorTextRegion()
 {
     return settings.value(SETTINGS_TRANSLATOR_TEXT_REGION, DEFAULT_TRANSLATOR_TEXT_REGION).toString();
+}
+
+bool Curiosity::secretsWriteKey(const QString &secretName, const QString &value)
+{
+    Sailfish::Secrets::CreateCollectionRequest createRequest;
+    createRequest.setManager(&secretManager);
+    createRequest.setCollectionName(QLatin1String(SECRETS_COLLECTION_NAME));
+    createRequest.setStoragePluginName(Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName);
+    createRequest.setEncryptionPluginName(Sailfish::Secrets::SecretManager::DefaultEncryptionPluginName);
+    createRequest.setAccessControlMode(Sailfish::Secrets::SecretManager::OwnerOnlyMode);
+    createRequest.setCollectionLockType(Sailfish::Secrets::CreateCollectionRequest::DeviceLock);
+    createRequest.setDeviceLockUnlockSemantic(Sailfish::Secrets::SecretManager::DeviceLockKeepUnlocked);
+    createRequest.startRequest();
+    createRequest.waitForFinished();
+
+    Sailfish::Secrets::Result createResult = createRequest.result();
+    if (createResult.code() == Sailfish::Secrets::Result::Failed
+            && createResult.errorCode() != Sailfish::Secrets::Result::CollectionAlreadyExistsError) {
+        qWarning() << "[Curiosity] Failed to create secrets collection:" << createResult.errorMessage();
+        return false;
+    }
+
+    Sailfish::Secrets::Secret::Identifier id(
+        secretName,
+        QLatin1String(SECRETS_COLLECTION_NAME),
+        Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName);
+    Sailfish::Secrets::Secret secret(id);
+    secret.setData(value.toUtf8());
+
+    Sailfish::Secrets::StoreSecretRequest storeRequest;
+    storeRequest.setManager(&secretManager);
+    storeRequest.setSecretStorageType(Sailfish::Secrets::StoreSecretRequest::CollectionSecret);
+    storeRequest.setSecret(secret);
+    storeRequest.startRequest();
+    storeRequest.waitForFinished();
+
+    Sailfish::Secrets::Result storeResult = storeRequest.result();
+    if (storeResult.code() == Sailfish::Secrets::Result::Failed) {
+        qWarning() << "[Curiosity] Failed to store secret" << secretName << ":" << storeResult.errorMessage();
+        return false;
+    }
+    return true;
+}
+
+QString Curiosity::secretsReadKey(const QString &secretName)
+{
+    Sailfish::Secrets::Secret::Identifier id(
+        secretName,
+        QLatin1String(SECRETS_COLLECTION_NAME),
+        Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName);
+
+    Sailfish::Secrets::StoredSecretRequest readRequest;
+    readRequest.setManager(&secretManager);
+    readRequest.setIdentifier(id);
+    readRequest.startRequest();
+    readRequest.waitForFinished();
+
+    if (readRequest.result().code() == Sailfish::Secrets::Result::Failed) {
+        return QString();
+    }
+    return QString::fromUtf8(readRequest.secret().data());
 }
 
 CloudApi *Curiosity::getCloudApi()

--- a/src/curiosity.h
+++ b/src/curiosity.h
@@ -23,6 +23,9 @@
 #include <QObject>
 #include <QSettings>
 #include <QNetworkAccessManager>
+#include <Secrets/secretmanager.h>
+#include <Secrets/secret.h>
+#include <Secrets/result.h>
 
 // Settings keys
 const char SETTINGS_SOURCE_LANGUAGE[] = "settings/sourceLanguage";
@@ -33,6 +36,11 @@ const char SETTINGS_COMPUTER_VISION_ENDPOINT[] = "settings/computerVisionEndpoin
 const char SETTINGS_TRANSLATOR_TEXT_KEY[] = "settings/translatorTextKey";
 const char SETTINGS_TRANSLATOR_TEXT_ENDPOINT[] = "settings/translatorTextEndpoint";
 const char SETTINGS_TRANSLATOR_TEXT_REGION[] = "settings/translatorTextRegion";
+
+// Sailfish Secrets identifiers
+const char SECRETS_COLLECTION_NAME[] = "harbour-wunderfitz-secrets";
+const char SECRETS_SECRET_CV_KEY[]    = "computerVisionKey";
+const char SECRETS_SECRET_TR_KEY[]    = "translatorTextKey";
 
 // Settings defaults
 const char DEFAULT_COMPUTER_VISION_ENDPOINT[] = "https://westeurope.api.cognitive.microsoft.com";
@@ -92,10 +100,12 @@ private:
     QString translatedText;
     QSettings settings;
     CloudApi *cloudApi;
-
     QNetworkAccessManager *networkAccessManager;
+    Sailfish::Secrets::SecretManager secretManager;
 
     void processCapture();
+    QString secretsReadKey(const QString &secretName);
+    bool secretsWriteKey(const QString &secretName, const QString &value);
 
 };
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,5 +1,5 @@
 CONFIG += sailfishapp
-LIBS += -lz -lquazip -L../quazip/quazip
+LIBS += -lz -lquazip -L$$OUT_PWD/../quazip/quazip
 
 QT += sql core
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -13,6 +13,8 @@ target.path = /usr/bin/
 TARGET = harbour-wunderfitz
 TEMPLATE = app
 
+LIBS += -lsailfishsecrets
+
 SOURCES += harbour-wunderfitz.cpp \
     databasemanager.cpp \
     heinzelnisseelement.cpp \

--- a/translations/harbour-wunderfitz-de.ts
+++ b/translations/harbour-wunderfitz-de.ts
@@ -136,16 +136,8 @@
         <translation>Cloud-API</translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation>Azure Computer Vision API-Schlüssel</translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
         <translation>Azure Translator Text API-Schlüssel</translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
-        <translation>Azure Computer Vision-Endpunkt</translation>
     </message>
     <message>
         <source>Azure Translator Text Endpoint</source>
@@ -154,6 +146,14 @@
     <message>
         <source>Azure Translator Text Region</source>
         <translation>Azure Translator Text-Region</translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation>Azure AI Vision API-Schlüssel</translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
+        <translation>Azure AI Vision-Endpunkt</translation>
     </message>
 </context>
 <context>
@@ -522,16 +522,36 @@
         <translation>Azure API-Schlüssel nicht gesetzt</translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation>Das Neugier-Feature - ein Bild aufnehmen und dann automatisch jeden erkannten Text darauf übersetzen - benötigt Microsoft Azure API-Schlüssel um zu funktionieren. Bitte besorgen Sie sich API-Schlüssel für die &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; und die &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, geben Sie diese auf der Einstellungen-Seite an und dann viel Spaß!</translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation>Einstellungen öffnen</translation>
     </message>
     <message>
         <source>Reload</source>
         <translation>Neu laden</translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation>Das Neugier-Feature benötigt Microsoft Azure API-Schlüssel. Bitte API-Schlüssel für &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; und &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; besorgen, auf der Einstellungsseite eingeben und viel Spaß!</translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation>Übersetzung in die Zwischenablage kopieren</translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation>Original in die Zwischenablage kopieren</translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation>Ergebnis</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation>Original</translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation>Übersetzung</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-wunderfitz-es.ts
+++ b/translations/harbour-wunderfitz-es.ts
@@ -136,16 +136,8 @@
         <translation>Nube</translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation>Llave del API AzureComputerVision</translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
         <translation>Llave del API AzureTranslatorText</translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Azure Translator Text Endpoint</source>
@@ -153,6 +145,14 @@
     </message>
     <message>
         <source>Azure Translator Text Region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -518,10 +518,6 @@
         <translation>AzureAPIKeys no establecida</translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation>La función Curiosidad, toma una foto y traduce automáticamente todo el texto reconocido en ella, necesita claves de la API de MicrosoftAzure para funcionar. Obtenga claves de API para &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, ingréselos en la página de configuración y ¡diviértanse!</translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation>Configuración abierta</translation>
     </message>
@@ -532,6 +528,30 @@
     <message>
         <source>Moreover, the Curiosity feature is beta! This means that there is no guarantee that it works as you wish or that it will continue working forever in this or a future version of Wunderfitz. It may cease to work without any prior warning...</source>
         <translation>¡Además, la función Curiosidad es beta! Esto significa que no hay garantía de que funcione como lo desee o que seguirá funcionando para siempre en esta o en una versión futura de Wunderfitz. Puede dejar de funcionar sin previo aviso ...</translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation type="unfinished">Copiar traducción</translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation type="unfinished">Copiar original</translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation type="unfinished">Resultados</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation type="unfinished">Original</translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished">Traducción</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-wunderfitz-hu.ts
+++ b/translations/harbour-wunderfitz-hu.ts
@@ -136,15 +136,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -153,6 +145,14 @@
     </message>
     <message>
         <source>Azure Translator Text Region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -518,10 +518,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -532,6 +528,30 @@
     <message>
         <source>Moreover, the Curiosity feature is beta! This means that there is no guarantee that it works as you wish or that it will continue working forever in this or a future version of Wunderfitz. It may cease to work without any prior warning...</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation type="unfinished">Fordítás másolása a vágólapra</translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation type="unfinished">Eredeti másolása a vágólapra</translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation type="unfinished">Eredmény</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation type="unfinished">Eredeti</translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished">Fordítás</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-wunderfitz-it.ts
+++ b/translations/harbour-wunderfitz-it.ts
@@ -136,15 +136,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -153,6 +145,14 @@
     </message>
     <message>
         <source>Azure Translator Text Region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -518,10 +518,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -532,6 +528,30 @@
     <message>
         <source>Moreover, the Curiosity feature is beta! This means that there is no guarantee that it works as you wish or that it will continue working forever in this or a future version of Wunderfitz. It may cease to work without any prior warning...</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation type="unfinished">Copia traduzione negli appunti</translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation type="unfinished">Copia originale negli appunti</translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation type="unfinished">Risultato</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation type="unfinished">Originale</translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished">Traduzione</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-wunderfitz-nl.ts
+++ b/translations/harbour-wunderfitz-nl.ts
@@ -136,15 +136,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -153,6 +145,14 @@
     </message>
     <message>
         <source>Azure Translator Text Region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -518,10 +518,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -531,6 +527,30 @@
     </message>
     <message>
         <source>Moreover, the Curiosity feature is beta! This means that there is no guarantee that it works as you wish or that it will continue working forever in this or a future version of Wunderfitz. It may cease to work without any prior warning...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-wunderfitz-pl.ts
+++ b/translations/harbour-wunderfitz-pl.ts
@@ -136,16 +136,8 @@
         <translation>Cloud API</translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation>Klucz Azure Computer Vision API</translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
         <translation>Klucz Azure Translator Text API</translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Azure Translator Text Endpoint</source>
@@ -153,6 +145,14 @@
     </message>
     <message>
         <source>Azure Translator Text Region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -518,10 +518,6 @@
         <translation>Klucze Azure API nie są ustawione</translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation>Funkcja Ciekawość - zrobienie zdjęcia i automatyczne przetłumaczenie znajdującego się na nim tekstu - wymaga do działania kluczy Microsoft Azure API. Uzyskaj klucze API dla &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, wprowadź je na stronie ustawień i baw się dobrze!</translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation>Otwórz ustawienia</translation>
     </message>
@@ -532,6 +528,30 @@
     <message>
         <source>Moreover, the Curiosity feature is beta! This means that there is no guarantee that it works as you wish or that it will continue working forever in this or a future version of Wunderfitz. It may cease to work without any prior warning...</source>
         <translation>Co więcej, funkcja Ciekawość jest w wersji beta! Oznacza to, że nie ma gwarancji, że będzie działała tak, jak chcesz lub że będzie działała wiecznie w tej lub przyszłej wersji Wunderfitz. Może przestać działać bez uprzedniego ostrzeżenia ...</translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation type="unfinished">Kopiuj tłumaczenie do schowka</translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation type="unfinished">Kopiuj oryginał do schowka</translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation type="unfinished">Wynik</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation type="unfinished">Oryginał</translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished">Tłumaczenie</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-wunderfitz-sk.ts
+++ b/translations/harbour-wunderfitz-sk.ts
@@ -136,16 +136,8 @@
         <translation>Cloud API</translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation>Kľúč API Azure Computer Vision</translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
         <translation>Kľúč API rozhrania Azure Translator Text</translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
-        <translation>Koncový bod Azure Computer Vision</translation>
     </message>
     <message>
         <source>Azure Translator Text Endpoint</source>
@@ -154,6 +146,14 @@
     <message>
         <source>Azure Translator Text Region</source>
         <translation>Textová oblasť prekladača Azure</translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -518,10 +518,6 @@
         <translation>Kľúče Azure API nie sú nastavené</translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation>Funkcia Curiosity - nasnímanie obrázku a automatické preloženie celého rozpoznaného textu na ňom - na svoju činnosť potrebuje kľúče Microsoft Azure API. Získajte kľúče API pre &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; a &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, zadajte ich na stránke nastavení a bavte sa!</translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation>Otvoriť nastavenia</translation>
     </message>
@@ -532,6 +528,30 @@
     <message>
         <source>Moreover, the Curiosity feature is beta! This means that there is no guarantee that it works as you wish or that it will continue working forever in this or a future version of Wunderfitz. It may cease to work without any prior warning...</source>
         <translation>Navyše, funkcia Curiosity je beta! To znamená, že neexistuje žiadna záruka, že funguje tak, ako si želáte, alebo že bude v tejto alebo budúcej verzii Wunderfitzu fungovať navždy. Môže prestať fungovať bez predchádzajúceho upozornenia...</translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation type="unfinished">Kopírovať preložené do schránky</translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation type="unfinished">Kopírovať pôvodné do schránky</translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation type="unfinished">Výsledok</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation type="unfinished">Pôvodné</translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished">Preložené</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-wunderfitz-sv.ts
+++ b/translations/harbour-wunderfitz-sv.ts
@@ -136,16 +136,8 @@
         <translation>Moln-API</translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation>Azure Computer Vision API-nyckel</translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
         <translation>Azure Translator Text API-nyckel</translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Azure Translator Text Endpoint</source>
@@ -153,6 +145,14 @@
     </message>
     <message>
         <source>Azure Translator Text Region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -518,10 +518,6 @@
         <translation>Azure API-nycklar ej angivna</translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation>Kuriositetsfunktionen - Att ta en bild och automatiskt översätta all tolkad text på den, kräver fungerande Microsoft Azure API-nycklar. Hämta API-nycklar för &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; och &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; Ange dem på inställningssidan och ha kul!</translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation>Öppna inställningarna</translation>
     </message>
@@ -532,6 +528,30 @@
     <message>
         <source>Moreover, the Curiosity feature is beta! This means that there is no guarantee that it works as you wish or that it will continue working forever in this or a future version of Wunderfitz. It may cease to work without any prior warning...</source>
         <translation>Dessutom är kuriositetsfunktionen beta! Detta innebär att det inte finns någon garanti för att det fungerar som du vill eller att det kommer att fortsätta fungera för evigt, i denna eller framtida versioner av Wunderfitz. Det kan upphöra att fungera utan förvarning...</translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation type="unfinished">Kopiera översättning till urklipp</translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation type="unfinished">Kopiera källtext till urklipp</translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation type="unfinished">Resultat</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation type="unfinished">Källtext</translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished">Översättning</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-wunderfitz-zh_CN.ts
+++ b/translations/harbour-wunderfitz-zh_CN.ts
@@ -137,16 +137,8 @@
         <translation>云服务 API</translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation>Azure 计算机版本 API 密钥</translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
         <translation>Azure 翻译器文本 API 密钥</translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Azure Translator Text Endpoint</source>
@@ -154,6 +146,14 @@
     </message>
     <message>
         <source>Azure Translator Text Region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -520,11 +520,6 @@
         <translation>未设置 Azure API 密钥</translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation>
-​智能识图功能——即拍照并自动翻译所有识别到的文本。此项功能需要用到 Microsoft  Azure API 密钥才能工作。请从下方链接获取 API 密钥 &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; 在设置页面输入它们。祝你愉快！</translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation>打开设置</translation>
     </message>
@@ -535,6 +530,30 @@
     <message>
         <source>Moreover, the Curiosity feature is beta! This means that there is no guarantee that it works as you wish or that it will continue working forever in this or a future version of Wunderfitz. It may cease to work without any prior warning...</source>
         <translation>智能识图功能尚处于测试阶段！我无法保证它取得符合你预期的效果以及承诺在今后的 Wunderfitz 版本中进一步完善此功能。此功能可能会在今后的开发中随时被移除，而不会提前告知你。</translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation type="unfinished">复制翻译到剪切板</translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation type="unfinished">复制原文到剪切板</translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation type="unfinished">结果</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation type="unfinished">原文</translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished">翻译</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-wunderfitz.ts
+++ b/translations/harbour-wunderfitz.ts
@@ -136,15 +136,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Azure Computer Vision API Key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Azure Translator Text API Key</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Azure Computer Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -153,6 +145,14 @@
     </message>
     <message>
         <source>Azure Translator Text Region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision API Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Azure AI Vision Endpoint</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -518,10 +518,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/computer-vision/&quot;&gt;Computer Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-gb/services/cognitive-services/translator-text-api/&quot;&gt;Translator Text&lt;/a&gt; API, enter them on the settings page and have fun!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -532,6 +528,30 @@
     <message>
         <source>Moreover, the Curiosity feature is beta! This means that there is no guarantee that it works as you wish or that it will continue working forever in this or a future version of Wunderfitz. It may cease to work without any prior warning...</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Curiosity feature - taking a picture and automatically translating all recognized text on it - needs Microsoft Azure API keys to work. Please obtain API keys for &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-vision&quot;&gt;Azure AI Vision&lt;/a&gt; and the &lt;a href=&quot;https://azure.microsoft.com/en-us/products/ai-services/ai-translator&quot;&gt;Azure AI Translator&lt;/a&gt; API, enter them on the settings page and have fun!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy translation to clipboard</source>
+        <translation type="unfinished">Copy translation to clipboard</translation>
+    </message>
+    <message>
+        <source>Copy original to clipboard</source>
+        <translation type="unfinished">Copy original to clipboard</translation>
+    </message>
+    <message>
+        <source>Result</source>
+        <translation type="unfinished">Result</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation type="unfinished">Original</translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished">Translation</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
  ## Summary

  - **Azure AI Vision API migration**: Update OCR endpoint from deprecated
    `/vision/v1.0/ocr` to Image Analysis v4.0
    (`/computervision/imageanalysis:analyze?api-version=2024-02-01&features=read`).
    Update response parsing from the old `regions[].lines[].words[]` format to
    the new `readResult.blocks[].lines[].text` format. Omit the `language`
    parameter when set to `unk` (auto-detect) as v4.0 rejects it.
  - **Improved error messages**: Parse and display actual Azure JSON error
    responses instead of generic Qt network errors.
  - **Settings labels**: Rename "Azure Computer Vision" to "Azure AI Vision"
    throughout the settings page.
  - **Result tab UI**: Use `SectionHeader` above `TextArea` for Original and
    Translation labels (so labels appear at the top, not the bottom). Move
    copy-to-clipboard pull-down menu items to the outer `PullDownMenu`, visible
    only when the Result tab is active.
  - **Build fixes**: Fix shadow build linker path for quazip; fix quazip build
    on Windows-mapped filesystems using `unversioned_libname`/`unversioned_soname`.
  - **Translations**: Add German translations for all new strings; update
    translation source template and all other language files.

  ## Test plan

  - [ ] Take a photo with the Curiosity feature; verify OCR text is extracted
    and translated correctly end-to-end
  - [ ] Verify "Azure AI Vision" and "Azure AI Translator" labels appear in
    Settings
  - [ ] On the Result tab, verify Original/Translation section headers appear
    at the top
  - [ ] On the Result tab, verify pull-down menu shows copy options
  - [ ] On a German-locale device, verify "Ergebnis", "Übersetzung" etc. appear
    instead of English strings